### PR TITLE
 Don't include clojure.jar into the image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -52,8 +52,6 @@ RUN cd /build/nginx-clojure-${NGINX_CLOJURE_VERSION} && \
     mkdir -p /usr/lib/nginx/jars && \
     cp target/nginx-clojure-${NGINX_CLOJURE_VERSION}-standalone.jar \
 	/usr/lib/nginx/jars/nginx-clojure.jar && \
-    cp $HOME/.m2/repository/org/clojure/clojure/1.5.1/clojure-1.5.1.jar \
-	/usr/lib/nginx/jars/ && \
     rm -rf $HOME/.m2 $HOME/.lein
 
 # Add config

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN apt-get update && \
             zlib1g-dev
 
 # Add sources
-ADD src /build/
+COPY src /build/
 
 # Build nginx with nginx-clojure module
 RUN cd /build/nginx-${NGINX_VERSION} && \
@@ -46,7 +46,7 @@ RUN cd /build/nginx-${NGINX_VERSION} && \
     make install
 
 # Build and copy nginx-clojure uberjar
-ADD scripts/lein /build/
+COPY scripts/lein /build/
 RUN cd /build/nginx-clojure-${NGINX_CLOJURE_VERSION} && \
     LEIN_ROOT=1 /build/lein uberjar && \
     mkdir -p /usr/lib/nginx/jars && \
@@ -57,8 +57,8 @@ RUN cd /build/nginx-clojure-${NGINX_CLOJURE_VERSION} && \
     rm -rf $HOME/.m2 $HOME/.lein
 
 # Add config
-ADD conf/nginx.conf /etc/nginx/nginx.conf
-ADD conf/clojure.conf /etc/nginx/conf.d/clojure.conf
+COPY conf/nginx.conf /etc/nginx/nginx.conf
+COPY conf/clojure.conf /etc/nginx/conf.d/clojure.conf
 RUN mkdir -p \
           /etc/nginx/conf.d \
           /etc/nginx/sites-available \

--- a/test/Dockerfile_bats
+++ b/test/Dockerfile_bats
@@ -6,6 +6,6 @@ RUN apt-get update && \
     apt-get install -y bats curl && \
     rm -rf /var/lib/apt/lists/*
 
-ADD scripts/ /tests/
+COPY scripts/ /tests/
 
 CMD /tests/run_tests

--- a/test/Dockerfile_test
+++ b/test/Dockerfile_test
@@ -4,3 +4,7 @@ COPY conf/test-site.html /usr/local/test-site/index.html
 
 COPY conf/test-site.nginx /etc/nginx/sites-available/yle-nginx-test
 RUN ln -s /etc/nginx/sites-available/yle-nginx-test /etc/nginx/sites-enabled/
+
+ADD https://repo1.maven.org/maven2/org/clojure/clojure/1.8.0/clojure-1.8.0.jar \
+    /usr/lib/nginx/jars/
+RUN chmod 0644 /usr/lib/nginx/jars/*.jar

--- a/test/Dockerfile_test
+++ b/test/Dockerfile_test
@@ -1,6 +1,6 @@
 FROM yle-nginx-clojure
 
-ADD conf/test-site.html /usr/local/test-site/index.html
+COPY conf/test-site.html /usr/local/test-site/index.html
 
-ADD conf/test-site.nginx /etc/nginx/sites-available/yle-nginx-test
+COPY conf/test-site.nginx /etc/nginx/sites-available/yle-nginx-test
 RUN ln -s /etc/nginx/sites-available/yle-nginx-test /etc/nginx/sites-enabled/

--- a/test/Makefile
+++ b/test/Makefile
@@ -13,7 +13,11 @@ clean:
 	-rm -rf .build_*
 
 test: .build_test .build_bats
-	$(DOCKER_COMPOSE) run --rm --name yle-nginx-bats-$(PID) bats
+	# Run the tests
+	$(DOCKER_COMPOSE) run --rm --name yle-nginx-bats-$(PID) bats || \
+	    { $(DOCKER_COMPOSE) logs nginx; exit 1; }
+
+	# Shut down everything
 	@# Unfortunately the `--rm` option above won't remove depended services,
 	@# i.e. nginx, so we have to stop it ourselves.
 	@# https://github.com/docker/compose/issues/2791

--- a/test/conf/test-site.nginx
+++ b/test/conf/test-site.nginx
@@ -4,8 +4,6 @@ server {
 
     root /usr/local/test-site;
 
-    access_log /var/log/nginx/access.log timed_combined;
-
     location = /clojure {
         handler_type 'clojure';
         handler_code '


### PR DESCRIPTION
Let the users of the image decide which clojure version they need, if
any. The jar can be included like here in the tests by just downloading
the jar, or using project.clj and uberjar.