### PR TITLE
Set owner for the log dir

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -61,7 +61,8 @@ RUN mkdir -p \
           /etc/nginx/conf.d \
           /etc/nginx/sites-available \
           /etc/nginx/sites-enabled \
-          /var/lib/nginx
+          /var/lib/nginx && \
+    chown -R www-data /var/log/nginx
 
 # Clean up
 RUN apt-get purge -y \


### PR DESCRIPTION
Even if the log dir is not used with the default configuration,
the directory is a build time default, so it is good to ensure
that the www-data user has write permissions to it.