### PR TITLE
Alpine runtime container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,23 +25,23 @@ RUN cd /build/nginx-${NGINX_VERSION} && \
     ./configure \
         --add-module=/build/nginx-clojure-${NGINX_CLOJURE_VERSION}/src/c \
         --prefix=/usr/share/nginx \
-	--sbin-path=/usr/sbin/nginx \
-	--conf-path=/etc/nginx/nginx.conf \
-	--error-log-path=/var/log/nginx/error.log \
-	--http-client-body-temp-path=/var/lib/nginx/body \
-	--http-fastcgi-temp-path=/var/lib/nginx/fastcgi \
-	--http-log-path=/var/log/nginx/access.log \
-	--http-proxy-temp-path=/var/lib/nginx/proxy \
-	--http-scgi-temp-path=/var/lib/nginx/scgi \
-	--http-uwsgi-temp-path=/var/lib/nginx/uwsgi \
-	--lock-path=/var/lock/nginx.lock \
-	--pid-path=/run/nginx.pid \
-	--with-http_realip_module \
-	--with-http_stub_status_module \
-	--with-http_ssl_module \
-	--with-ipv6 \
-	--with-sha1=/usr/include/openssl \
-	--with-md5=/usr/include/openssl && \
+        --sbin-path=/usr/sbin/nginx \
+        --conf-path=/etc/nginx/nginx.conf \
+        --error-log-path=/var/log/nginx/error.log \
+        --http-client-body-temp-path=/var/lib/nginx/body \
+        --http-fastcgi-temp-path=/var/lib/nginx/fastcgi \
+        --http-log-path=/var/log/nginx/access.log \
+        --http-proxy-temp-path=/var/lib/nginx/proxy \
+        --http-scgi-temp-path=/var/lib/nginx/scgi \
+        --http-uwsgi-temp-path=/var/lib/nginx/uwsgi \
+        --lock-path=/var/lock/nginx.lock \
+        --pid-path=/run/nginx.pid \
+        --with-http_realip_module \
+        --with-http_stub_status_module \
+        --with-http_ssl_module \
+        --with-ipv6 \
+        --with-sha1=/usr/include/openssl \
+        --with-md5=/usr/include/openssl && \
     make && \
     make install
 
@@ -51,7 +51,7 @@ RUN cd /build/nginx-clojure-${NGINX_CLOJURE_VERSION} && \
     LEIN_ROOT=1 /build/lein uberjar && \
     mkdir -p /usr/lib/nginx/jars && \
     cp target/nginx-clojure-${NGINX_CLOJURE_VERSION}-standalone.jar \
-	/usr/lib/nginx/jars/nginx-clojure.jar && \
+        /usr/lib/nginx/jars/nginx-clojure.jar && \
     rm -rf $HOME/.m2 $HOME/.lein
 
 # Add config

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:8
+FROM openjdk:8-jdk-alpine
 
 ARG NGINX_VERSION
 ARG NGINX_CLOJURE_VERSION
@@ -8,14 +8,14 @@ ENV NGINX_CLOJURE_VERSION $NGINX_CLOJURE_VERSION
 ENV DEBIAN_FRONTEND noninteractive
 
 # Upgrade the OS and install build dependencies
-RUN apt-get update && \
-    apt-get upgrade -y && \
-    apt-get install -y --no-install-recommends \
-            gcc \
-            libpcre3-dev \
-            libssl-dev \
-            make \
-            zlib1g-dev
+RUN apk update --no-cache && \
+    apk upgrade --no-cache && \
+    apk add --no-cache \
+        bash \
+        build-base \
+        pcre-dev \
+        openssl-dev \
+        zlib-dev
 
 # Add sources
 COPY src /build/
@@ -41,6 +41,8 @@ RUN cd /build/nginx-${NGINX_VERSION} && \
         --with-http_ssl_module \
         --with-ipv6 \
         --with-sha1=/usr/include/openssl \
+        # Building in Alpine defaults to error from warnings, which differs from previously used Debian
+        --with-cc-opt="-Wno-error" \
         --with-md5=/usr/include/openssl && \
     make && \
     make install
@@ -57,21 +59,47 @@ RUN cd /build/nginx-clojure-${NGINX_CLOJURE_VERSION} && \
 # Add config
 COPY conf/nginx.conf /etc/nginx/nginx.conf
 COPY conf/clojure.conf /etc/nginx/conf.d/clojure.conf
+
+# -------------------------------------------------------------------
+# Build the runtime container
+# -------------------------------------------------------------------
+FROM openjdk:8-jre-alpine
+
+ARG NGINX_CLOJURE_VERSION
+ENV NGINX_CLOJURE_VERSION ${NGINX_CLOJURE_VERSION}
+
+RUN apk update --no-cache && \
+    apk upgrade --no-cache && \
+    apk add --no-cache pcre
+
+# ensure www-data user exists
+RUN set -x ; \
+  addgroup -g 82 -S www-data ; \
+  adduser -u 82 -D -S -G www-data www-data
+
 RUN mkdir -p \
           /etc/nginx/conf.d \
           /etc/nginx/sites-available \
           /etc/nginx/sites-enabled \
+          /usr/lib/nginx/jars \
+          /usr/sbin \
+          /usr/share \
+          /var/log/nginx \
           /var/lib/nginx && \
     chown -R www-data /var/log/nginx
 
-# Clean up
-RUN apt-get purge -y \
-            gcc \
-            libpcre3-dev \
-            libssl-dev \
-            make \
-            zlib1g-dev && \
-    apt-get autoremove -y && \
-    rm -rf /build /var/lib/apt/lists/*
+COPY --from=0 /usr/sbin/nginx /usr/sbin/nginx
+RUN chmod -R 755 /usr/sbin/nginx
+
+COPY --from=0 /etc/nginx/ /etc/nginx/
+RUN rm -f /etc/nginx/*.default
+COPY --from=0 /etc/nginx/conf.d/clojure.conf /etc/nginx/conf.d/clojure.conf
+
+COPY --from=0 /usr/lib/nginx/jars/nginx-clojure.jar /usr/lib/nginx/jars/nginx-clojure.jar
+
+COPY --from=0 /usr/share/nginx/ /usr/share/nginx/
+
+# I don't know if this is a bug or what, but libjvm.so could not be found from under server directory.
+RUN ln -s /usr/lib/jvm/java-1.8-openjdk/jre/lib/amd64/server/libjvm.so /usr/lib/jvm/java-1.8-openjdk/jre/lib/amd64/libjvm.so
 
 CMD /usr/sbin/nginx -g 'daemon off;'


### PR DESCRIPTION
Use Alpine (openjdk:8-jdk-alpine) as build platform
Use Alpine (openjdk:8-jre-alpine) as runtime

Had to explicitly ignore warnings when building nginx-clojure.

I have no idea if `--no-cache` has any effect on update&upgrade.

I'm released this as `1.12.2-0.4.5-2.1`, `1.12.2-0.4.5-alpine` and `latest`. It can be a breaking change to many things, but as far as I know, at the moment we are the only one using this. Version `1.12.2-0.4.5` will stay as it is until the heat death of the universe. [Docker Hub](https://cloud.docker.com/u/yleisradio/repository/docker/yleisradio/yle-nginx-clojure/tags)