### PR TITLE
FIX: keep alive idle timeout on ALB and NGINX does not work together

### DIFF
--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -16,6 +16,7 @@ http {
 
 	# Timeout for keep-alive connections. Server will close connections after this time.
 	keepalive_timeout 120s;
+	client_header_timeout 120s; # this should be > ALB keep alive idle timeout (default 60s)
 
 	sendfile on;
 	tcp_nopush on;


### PR DESCRIPTION
NGINX closes the connection after a certain timeout which is not recorded by ALB, thus ALB attempts to send a message to NGINX even if NGINX has closed the connection already. This timeout setting should avoid that situation and let ALB handle the closing of the connection.

A great blog post about what is happening is written here:
https://sigopt.com/blog/the-case-of-the-mysterious-aws-elb-504-errors/
